### PR TITLE
Load/Exec Address fixes and a title command

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,4 +2,6 @@
 afsls
 afstree
 afscp
+afschk
+afstitle
 acorn-fs-utils.geany

--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ CFLAGS	= -O2 -Wall
 
 LIB_MODULES = acorn-fs.o acorn-adfs.o acorn-dfs.o
 
-all: afsls afstree afscp afschk
+all: afsls afstree afscp afschk afstitle
 
 afsls: afsls.o $(LIB_MODULES)
 
@@ -13,5 +13,7 @@ afstree: afstree.o $(LIB_MODULES)
 afscp: afscp.o $(LIB_MODULES)
 
 afschk: afschk.o  $(LIB_MODULES)
+
+afstitle: afstitle.o  $(LIB_MODULES)
 
 *.o: acorn-fs.h

--- a/acorn-adfs.c
+++ b/acorn-adfs.c
@@ -468,9 +468,9 @@ static int dir_update(acorn_fs *fs, acorn_fs_object *parent, acorn_fs_object *ch
     if (a & AFS_ATTR_OWRITE) ent[6] |= 0x80;
     if (a & AFS_ATTR_OEXEC)  ent[7] |= 0x80;
     if (a & AFS_ATTR_PRIV)   ent[8] |= 0x80;
-    adfs_put24(ent + 0x0a, child->load_addr);
-    adfs_put24(ent + 0x0e, child->exec_addr);
-    adfs_put24(ent + 0x12, child->length);
+    adfs_put32(ent + 0x0a, child->load_addr);
+    adfs_put32(ent + 0x0e, child->exec_addr);
+    adfs_put32(ent + 0x12, child->length);
     adfs_put24(ent + 0x16, child->sector);
     return fs->wrsect(fs, parent->sector, parent->data, parent->length);
 }

--- a/acorn-dfs.c
+++ b/acorn-dfs.c
@@ -89,6 +89,22 @@ static int dfs_find(acorn_fs *fs, const char *dfs_name, acorn_fs_object *obj)
     return ENOENT;
 }
 
+static int dfs_settitle(acorn_fs *fs, const char *title)
+{
+    // In DFS the title is 12 character, written to:
+    // Sector 0, bytes 0..7
+    // Sector 1, bytes 0..3
+    // Padding is typically spaces
+    unsigned char *dir = fs->priv;
+    for (int i = 0; i < 12; i++) {
+        char c = (i < strlen(title)) ? title[i] : ' ';
+        int di = (i > 8) ? 0x100 + i - 8 : i;
+        // Update the directory
+        dir[di] = c;
+    }
+    return fs->wrsect(fs, 0, dir, 0x200);
+}
+
 static int dfs_glob(acorn_fs *fs, acorn_fs_object *start, const char *pattern, acorn_fs_cb cb, void *udata)
 {
     unsigned char *dir = fs->priv;
@@ -297,4 +313,5 @@ void acorn_fs_dfs_init(acorn_fs *fs)
     fs->load  = dfs_load;
     fs->save  = dfs_save;
     fs->check = acorn_fs_dfs_check;
+    fs->settitle = dfs_settitle;
 }

--- a/acorn-fs.c
+++ b/acorn-fs.c
@@ -3,6 +3,10 @@
 #include <stdlib.h>
 #include <string.h>
 
+#ifndef WIN32
+#include <fcntl.h>
+#endif
+
 static acorn_fs *open_list;
 
 static int check_adfs(FILE *fp, unsigned off1, unsigned off2, const char *pattern, size_t len)
@@ -145,8 +149,6 @@ static int lock_file(FILE *fp, bool writable)
 #ifdef WIN32
     return AFS_OK
 #else
-#include <fcntl.h>
-
     struct flock fl;
     int fd = fileno(fp);
 

--- a/acorn-fs.h
+++ b/acorn-fs.h
@@ -53,6 +53,7 @@ struct acorn_fs {
     int (*check)(acorn_fs *fs, const char *fsname, FILE *mfp);
     int (*rdsect)(acorn_fs *fs, int ssect, unsigned char *buf, unsigned size);
     int (*wrsect)(acorn_fs *fs, int ssect, unsigned char *buf, unsigned size);
+    int (*settitle)(acorn_fs *fs, const char *title);
     FILE *fp;
     void *priv;
     acorn_fs *next;

--- a/afstitle.c
+++ b/afstitle.c
@@ -1,0 +1,23 @@
+#include "acorn-fs.h"
+
+int main(int argc, char *argv[])
+{
+    if (argc == 3) {
+        int status;
+        const char *fsname = *++argv;
+        acorn_fs *fs = acorn_fs_open(fsname, true);
+        if (fs) {
+            const char *title = *++argv;
+            int astat = fs->title(fs, title);
+            if (astat != AFS_OK) {
+                status++;
+            }
+        }
+        acorn_fs_close_all();
+        return status;
+    }
+    else {
+        fputs("Usage: afstitle <acorn-fs-image> <title>\n", stderr);
+        return 1;
+    }
+}


### PR DESCRIPTION
Hi Steve,

Thanks for sorting the interleave.

Thanks also for fixing the .inf issue - this has simplified my build script.

Here's a pull request for three small things:
- a minor build fix with include files
- a update the written ADFS address/length fields from 24-bit to 32-bit
- added an afstitle command

Here's my latest AcornOS120 ADFS build script using these:
https://github.com/stardot/AcornOS120/blob/dev/adfs/make_disk_images.sh

Dave
 